### PR TITLE
 Fix: Command History Not Available in SSH Sessions

### DIFF
--- a/src/App_new.tsx
+++ b/src/App_new.tsx
@@ -719,7 +719,7 @@ function App() {
             id: `session-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`,
             config: { ...config },
             terminalLogs: [],
-            commandHistory: [],
+            commandHistory: [...commandHistory], // Use global command history
             historyIndex: -1,
             currentDirectory: '/home',
             sessionId: newSessionId,


### PR DESCRIPTION
##  Command History Fix for SSH Sessions

### **Problem Solved:**
**Command history was not accessible when connected to remote SSH servers**

Users could not use arrow keys to navigate through previously executed commands in SSH sessions, severely impacting productivity.

### **Root Cause:**
-  **Global command history loaded successfully** (50+ commands)
-  **New SSH sessions initialized with empty command history**
-  **Arrow key navigation used session's empty history**

### **The Fix:**
**Modified session creation to inherit global command history:**

`	sx
// Before (Broken)
const newSession: TerminalSession = {
  // ...
  commandHistory: [],  //  Empty array
  // ...
};

// After (Fixed)  
const newSession: TerminalSession = {
  // ...
  commandHistory: [...commandHistory],  //  Inherits global history
  // ...
};
`

### **What This Fixes:**
-  **Arrow key navigation** now works in SSH sessions
-  **Command history** is immediately available after connecting
-  **All 50+ commands** are accessible for navigation
-  **No breaking changes** to existing functionality

### **Technical Details:**
- **File Modified:** src/App_new.tsx (1 line change)
- **Impact:** Minimal, targeted fix
- **Testing:** Verified with SSH server connection
- **Backward Compatible:** Yes

### **Before vs After:**

**Before Fix:**
`
SSH Connection  New Session  commandHistory: []  Arrow keys: No history
`

**After Fix:**
`
SSH Connection  New Session  commandHistory: [50+ commands]  Arrow keys: Full history 
`

### **Verification:**
-  Build passes without errors
-  SSH connections work normally  
-  Command history loads immediately
-  Arrow key navigation functions properly
-  Commands save to both global and session history

### **Impact on Users:**
- **High Productivity Gain**: No more retyping complex commands
- **Better UX**: Seamless command history experience
- **No Learning Curve**: Works exactly as expected

### **Files Changed:**
- src/App_new.tsx - Fixed session creation logic (1 line)

### **Testing Instructions:**
1. Connect to SSH server
2. Execute a few commands
3. Press  arrow key  Should show command history
4. Press  arrow key  Should navigate through history
5. Disconnect and reconnect  History should still be available

---

**This is a critical UX fix that resolves a major productivity blocker for SSH users.** 

Closes: Command history preservation issue in SSH sessions