### PR TITLE
feat: expand terminal and SFTP file list area height

### DIFF
--- a/src/App_new.tsx
+++ b/src/App_new.tsx
@@ -1752,7 +1752,7 @@ function App() {
                   <div
                     className="powershell-scrollbar"
                     style={{
-                      height: '400px',
+                      height: '600px',
                       overflowY: 'auto',
                       padding: '1rem',
                       fontFamily: 'Consolas, Monaco, "Courier New", monospace',
@@ -2083,7 +2083,7 @@ function App() {
                   )}
 
                   {/* File List */}
-                  <div style={{ maxHeight: '400px', overflowY: 'auto' }}>
+                  <div style={{ maxHeight: '600px', overflowY: 'auto' }}>
                     {remoteFiles.length === 0 ? (
                       <div style={{ padding: '2rem', textAlign: 'center', color: '#94a3b8' }}>
                         {isConnected ? 'No files in this directory' : 'Connect to a server to browse files'}


### PR DESCRIPTION
##  **Terminal Area Expansion Feature**

### **Overview**
This PR implements the terminal area expansion feature to improve the user experience by providing more vertical space for terminal operations and file browsing.

### **Changes Made**
- **Terminal Interface Height**: Increased from 400px to 600px (50% expansion)
- **SFTP File Browser Height**: Increased from 400px to 600px for consistency
- **File Modified**: src/App_new.tsx (lines 1755 and 2086)

### **Benefits**
 **Enhanced User Experience**: 50% more vertical space for terminal commands and output  
 **Better Visibility**: More command history and responses visible at once  
 **Improved Productivity**: Easier to work with long terminal outputs  
 **Consistent Design**: Both terminal and file browser areas have matching heights  
 **Responsive**: Maintains scrolling functionality for overflow content  

### **Technical Details**
- **Build Status**:  All builds pass successfully
- **Linting**:  No new linting issues introduced
- **Testing**:  Ready for manual testing and user feedback

### **Screenshots/Testing**
To test this feature:
1. Run 
pm run dev to start the development server
2. Navigate to the terminal tab
3. Verify the terminal area now has more vertical space
4. Test both SSH terminal and SFTP file browser areas

### **Related Issues**
- Closes #41 (Terminal Area Expansion)
- Part of ongoing UI/UX improvements for QuantumXfer

### **Priority**
**Medium** - UI enhancement that improves user experience

---

**Note**: This feature provides a much better terminal experience with significantly more space for operations and file browsing.