### PR TITLE
feat: bookmarks for servers and directories

### DIFF
--- a/electron/preload.js
+++ b/electron/preload.js
@@ -37,6 +37,13 @@ contextBridge.exposeInMainWorld('electronAPI', {
     getConnections: () => ipcRenderer.invoke('ssh-get-connections')
   },
   
+  // Bookmarks
+  bookmarks: {
+    list: () => ipcRenderer.invoke('bookmarks-list'),
+    add: (bookmark) => ipcRenderer.invoke('bookmarks-add', bookmark),
+    remove: (bookmarkId) => ipcRenderer.invoke('bookmarks-remove', bookmarkId)
+  },
+  
   // Menu actions
   onMenuNewConnection: (callback) => ipcRenderer.on('menu-new-connection', callback),
   onMenuLogsDirectory: (callback) => ipcRenderer.on('menu-logs-directory', callback),

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "quantumxfer-app",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "quantumxfer-app",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "hasInstallScript": true,
       "dependencies": {
         "@tailwindcss/postcss7-compat": "^2.2.17",

--- a/src/types/electron.d.ts
+++ b/src/types/electron.d.ts
@@ -34,6 +34,13 @@ export interface ElectronAPI {
   loadCommandHistory: () => Promise<{ success: boolean; commands: string[]; error?: string }>;
   appendCommandHistory: (data: { command: string }) => Promise<{ success: boolean; commands: string[]; error?: string }>;
   
+  // Bookmarks management
+  bookmarks: {
+    list: () => Promise<{ success: boolean; bookmarks: Bookmark[]; error?: string }>;
+    add: (bookmark: NewBookmark) => Promise<{ success: boolean; bookmarks?: Bookmark[]; error?: string }>;
+    remove: (bookmarkId: string) => Promise<{ success: boolean; bookmarks?: Bookmark[]; error?: string }>;
+  };
+  
   // Menu actions
   onMenuNewConnection: (callback: () => void) => void;
   onMenuLogsDirectory: (callback: () => void) => void;
@@ -126,6 +133,33 @@ export interface ConnectionProfile {
   tags?: string[];
   sshKeyPath?: string;
   jumpHost?: string;
+}
+
+export type BookmarkType = 'directory' | 'server';
+
+export interface ServerRef {
+  host: string;
+  port: number;
+  username?: string;
+}
+
+export interface Bookmark {
+  id: string;
+  type: BookmarkType;
+  label: string;
+  createdAt: string;
+  // For server bookmarks
+  server?: ServerRef | null;
+  // For directory bookmarks (SFTP remote path)
+  path?: string | null;
+}
+
+export interface NewBookmark {
+  type: BookmarkType;
+  label?: string;
+  server?: ServerRef | null;
+  path?: string | null;
+  id?: string;
 }
 
 declare global {


### PR DESCRIPTION
This PR adds a bookmarks feature that allows users to save servers and SFTP directories for quick navigation.\n\nHighlights:\n- Persistent bookmarks stored in userData/bookmarks/bookmarks.json\n- Electron IPC handlers: bookmarks-list/add/remove\n- Preload bridge exposing window.electronAPI.bookmarks\n- UI: sidebar list, add/remove actions, server and directory flows\n- Auto-generated profile name from username@host:port until manually overridden\n\nTested on Windows dev mode (Electron+Vite).