### PR TITLE
ci: add GitHub Actions for CI and Releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,61 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    name: Lint and Build (Web)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Typecheck and Build
+        run: npm run build
+
+  electron-smoke:
+    name: Electron Smoke Build (matrix)
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build web assets
+        run: npm run build
+
+      - name: Electron builder (Linux)
+        if: matrix.os == 'ubuntu-latest'
+        run: npx electron-builder --linux --dir
+
+      - name: Electron builder (Windows)
+        if: matrix.os == 'windows-latest'
+        run: npx electron-builder --win --dir

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,76 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+  workflow_dispatch:
+
+jobs:
+  build-release:
+    name: Build and Upload Release Artifacts
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build web assets
+        run: npm run build
+
+      - name: Build Electron packages
+        run: |
+          if [[ "$RUNNER_OS" == "Windows" ]]; then
+            npx electron-builder --win
+          else
+            npx electron-builder --linux
+          fi
+        shell: bash
+
+      - name: Archive artifacts (Linux)
+        if: runner.os == 'Linux'
+        run: |
+          ls -la dist-electron || true
+        shell: bash
+
+      - name: Archive artifacts (Windows)
+        if: runner.os == 'Windows'
+        run: |
+          dir dist-electron
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: quantumxfer-${{ runner.os }}
+          path: |
+            dist-electron/**
+
+  create-gh-release:
+    name: Create GitHub Release
+    needs: build-release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: ./artifacts
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            artifacts/**
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -55,5 +55,5 @@ dist-packager
 # Note: Consider using Git LFS for large binary files
 dist-packager/*.zip
 
-# GitHub directory
-.github/
+# GitHub directory (allow workflows and other repo config)
+


### PR DESCRIPTION
This PR sets up GitHub Actions for CI and automated releases.\n\nHighlights:\n- CI workflow (ci.yml):\n  - Node 22, npm ci, lint, build.\n  - Smoke Electron packaging on Ubuntu and Windows.\n- Release workflow (release.yml):\n  - Triggers on tag push or manual dispatch.\n  - Builds artifacts via electron-builder on Ubuntu and Windows.\n  - Uploads build artifacts and creates a GitHub Release.\n\nNotes:\n- .gitignore ignored .github; committed with force-add. Consider updating .gitignore to allow workflows.\n- Please review secrets/permissions as needed for releases.