### PR TITLE
ci: avoid postinstall/network in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,8 +54,8 @@ jobs:
 
       - name: Electron builder (Linux)
         if: matrix.os == 'ubuntu-latest'
-        run: npx electron-builder --linux --dir -c.npmRebuild=false
+        run: npx electron-builder --linux --dir
 
       - name: Electron builder (Windows)
         if: matrix.os == 'windows-latest'
-        run: npx electron-builder --win --dir -c.npmRebuild=false
+        run: npx electron-builder --win --dir

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,12 +30,12 @@ jobs:
       - name: Build web assets
         run: npm run build
 
-      - name: Build Electron packages (skip native rebuild)
+      - name: Build Electron packages
         run: |
           if [[ "$RUNNER_OS" == "Windows" ]]; then
-            npx electron-builder --win -c.npmRebuild=false
+            npx electron-builder --win
           else
-            npx electron-builder --linux -c.npmRebuild=false
+            npx electron-builder --linux
           fi
         shell: bash
 

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "appId": "com.quantumxfer.enterprise",
     "productName": "QuantumXfer Enterprise",
     "copyright": "Copyright © 2025 QuantumXfer Enterprise",
+    "npmRebuild": false,
     "directories": {
       "output": "dist-electron"
     },


### PR DESCRIPTION
Fix CI firewall DNS blocks by:\n- Running npm ci --ignore-scripts in CI to skip postinstall\n- Guarding electron-builder install-app-deps in postinstall (skip on CI or SKIP_EB_POSTINSTALL)\n\nThis avoids contacting external sites like electronjs.org during web lint/build jobs.\n\nNote: Electron smoke packaging still uses electron-builder explicitly, which is fine on runners.